### PR TITLE
Spelling fixes for Enchanter

### DIFF
--- a/globals.zil
+++ b/globals.zil
@@ -353,7 +353,7 @@ be impossible to scale." CR>)>>
 	 <COND (<AND <VERB? EXAMINE> <EQUAL? ,PRSO ,GLOBAL-WATER>>
 		<COND (<EQUAL? ,HERE ,BEACH>
 		       <TELL
-"The ocean streches out as far as the eye can see to the south and
+"The ocean stretches out as far as the eye can see to the south and
 east." CR>)
 		      (<EQUAL? ,HERE ,FOREST-2>
 		       <TELL

--- a/terror.zil
+++ b/terror.zil
@@ -833,7 +833,7 @@ Implementers." CR>)
 	(TEXT
 "This legend, written in an ancient tongue, goes something like this:
 At one time a shapeless and formless manifestation of evil was disturbed
-from millenia of sleep. It was so powerful that it required the combined
+from millennia of sleep. It was so powerful that it required the combined
 wisdom of the leading enchanters of that age to conquer it. The legend tells
 how the enchanters lured the Terror \"to a recess deep within the earth\" by
 placing there a powerful spell scroll. When it had reached the scroll, the

--- a/verbs.zil
+++ b/verbs.zil
@@ -1363,7 +1363,7 @@ slivers which evaporate instantaneously."
 
 <ROUTINE V-ZORK ()
 	 <TELL
-"ZORK (R) - A trilogy of fantasy classics from INFOCOM. " CR>>
+"ZORK (R) - A trilogy of fantasy classics from INFOCOM." CR>>
 
 \
 


### PR DESCRIPTION
These are the spelling fixes for Enchanter from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.